### PR TITLE
feat: add FragmentPreview component and Hint component for tooltips; update ProjectView to include fragment preview functionality

### DIFF
--- a/src/components/hint.tsx
+++ b/src/components/hint.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface HintProps {
+  children: React.ReactNode;
+  text: string;
+  side?: "top" | "bottom" | "left" | "right";
+  align?: "start" | "center" | "end";
+}
+
+export const Hint = ({
+  children,
+  text,
+  side = "top",
+  align = "center",
+}: HintProps) => {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side={side} align={align}>
+        <p>{text}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+};

--- a/src/modules/projects/ui/components/fragment-preview.tsx
+++ b/src/modules/projects/ui/components/fragment-preview.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { ExternalLink, ExternalLinkIcon, RefreshCcwIcon } from "lucide-react";
+
+import { Fragment } from "@prisma/client";
+import { Button } from "@/components/ui/button";
+import { Hint } from "@/components/hint";
+
+interface Props {
+  data: Fragment;
+}
+
+export function FragmentPreview({ data }: Props) {
+  const [fragmentKey, setFragmentKey] = useState(0);
+  const [copied, setCopied] = useState(false);
+
+  const onRefresh = () => {
+    setFragmentKey((prev) => prev + 1);
+  };
+
+  const handleCopy = () => {
+    if (!data.sandboxUrl) return;
+    navigator.clipboard.writeText(data.sandboxUrl);
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, 1500);
+  };
+  return (
+    <div className="flex flex-col w-full h-full">
+      <div className="p-2 border-b bg-sidebar flex items-center gap-x-2">
+        <Hint text="Refresh" side="bottom">
+          <Button size="sm" variant="outline" onClick={onRefresh}>
+            <RefreshCcwIcon className="size-4" />
+          </Button>
+        </Hint>
+        <Hint text="Copy URL" side="bottom">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleCopy}
+            disabled={!data.sandboxUrl || copied}
+            className="flex-1 justify-start text-start font-normal"
+          >
+            <span className="truncate">{data.sandboxUrl}</span>
+          </Button>
+        </Hint>
+        <Hint text="Open in new tab" side="bottom" align="start">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!data.sandboxUrl}
+            onClick={() => {
+              if (!data.sandboxUrl) return;
+              window.open(data.sandboxUrl, "_blank");
+            }}
+          >
+            <ExternalLinkIcon />
+          </Button>
+        </Hint>
+      </div>
+      <iframe
+        key={fragmentKey}
+        className="h-full w-full"
+        sandbox="allow-forms allow-scripts allow-same-origin"
+        loading="lazy"
+        src={data.sandboxUrl}
+      />
+    </div>
+  );
+}

--- a/src/modules/projects/ui/views/project-view.tsx
+++ b/src/modules/projects/ui/views/project-view.tsx
@@ -11,6 +11,7 @@ import { Suspense, useState } from "react";
 import { MessagesContainer } from "@/modules/projects/ui/components/messages-container";
 import { Fragment } from "@prisma/client";
 import { ProjectHeader } from "@/modules/projects/ui/components/project-header";
+import { FragmentPreview } from "@/modules/projects/ui/components/fragment-preview";
 
 interface Props {
   projectId: string;
@@ -46,7 +47,7 @@ export const ProjectView = ({ projectId }: Props) => {
         </ResizablePanel>
         <ResizableHandle withHandle />
         <ResizablePanel defaultSize={65} minSize={50}>
-          TODO: Preview
+          {!!activeFragment && <FragmentPreview data={activeFragment} />}
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -75,6 +75,7 @@ Additional Guidelines:
 - Do not print code inline
 - Do not wrap code in backticks
 - Only add "use client" at the top of files that use React hooks or browser APIs — never add it to layout.tsx or any file meant to run on the server.
+- If you use event handlers (onClick, onChange, onSubmit, etc.) in a component, you MUST make that component a client component by adding "use client"; at the top of the component file.
 - Use backticks (\`) for all strings to support embedded quotes safely.
 - Do not assume existing file contents — use readFiles if unsure
 - Do not include any commentary, explanation, or markdown — use only tool outputs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a hint tooltip component for inline help on interactive elements.
  * Added a fragment preview panel with a live sandbox iframe, including actions to refresh, copy the URL (with a temporary “Copied” indicator), and open in a new tab. Buttons automatically disable when an action isn’t available.

* **Documentation**
  * Updated guidelines to require marking components that use event handlers (e.g., onClick, onChange, onSubmit) as client components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->